### PR TITLE
Update aws_c_event_stream_jll to version 0.5.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsEventStream"
 uuid = "7707c54a-f152-44d3-a3d6-cc4209ac0b85"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,8 +17,8 @@ LibAwsCal = "1.1"
 LibAwsChecksums = "1.1"
 LibAwsCommon = "1.2"
 LibAwsIO = "1.2"
-aws_c_event_stream_jll = "=0.4.2"
 Test = "1.11"
+aws_c_event_stream_jll = "=0.5.4"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_checksums_jll = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
 [compat]
 Clang = "0.18.3,0.19"
 JLLPrefixes = "0.3,0.4"
-aws_c_event_stream_jll = "=0.4.2"
+aws_c_event_stream_jll = "=0.5.4"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_76
+    union (unnamed at /home/runner/.julia/artifacts/f6dcca8fbaffe17edce4486b00a838060e3fc1cb/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_76
+struct var"union (unnamed at /home/runner/.julia/artifacts/f6dcca8fbaffe17edce4486b00a838060e3fc1cb/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_76}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f6dcca8fbaffe17edce4486b00a838060e3fc1cb/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_76, f::Symbol)
-    r = Ref{__JL_Ctag_76}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_76}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f6dcca8fbaffe17edce4486b00a838060e3fc1cb/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f6dcca8fbaffe17edce4486b00a838060e3fc1cb/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f6dcca8fbaffe17edce4486b00a838060e3fc1cb/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_76}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f6dcca8fbaffe17edce4486b00a838060e3fc1cb/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_76}(x + 136)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f6dcca8fbaffe17edce4486b00a838060e3fc1cb/include/aws/event-stream/event_stream.h:96:5)"}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_206
+    union (unnamed at /home/runner/.julia/artifacts/a2319829f3da5ddaf638f084bb6ab60291947453/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_206
+struct var"union (unnamed at /home/runner/.julia/artifacts/a2319829f3da5ddaf638f084bb6ab60291947453/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_206}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2319829f3da5ddaf638f084bb6ab60291947453/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_206, f::Symbol)
-    r = Ref{__JL_Ctag_206}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_206}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a2319829f3da5ddaf638f084bb6ab60291947453/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a2319829f3da5ddaf638f084bb6ab60291947453/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2319829f3da5ddaf638f084bb6ab60291947453/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_206}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2319829f3da5ddaf638f084bb6ab60291947453/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_206}(x + 136)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2319829f3da5ddaf638f084bb6ab60291947453/include/aws/event-stream/event_stream.h:96:5)"}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_86
+    union (unnamed at /home/runner/.julia/artifacts/27151a7e29555d778aeca6b9e9891706f528db86/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_86
+struct var"union (unnamed at /home/runner/.julia/artifacts/27151a7e29555d778aeca6b9e9891706f528db86/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_86}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27151a7e29555d778aeca6b9e9891706f528db86/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_86, f::Symbol)
-    r = Ref{__JL_Ctag_86}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_86}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/27151a7e29555d778aeca6b9e9891706f528db86/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/27151a7e29555d778aeca6b9e9891706f528db86/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27151a7e29555d778aeca6b9e9891706f528db86/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_86}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27151a7e29555d778aeca6b9e9891706f528db86/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_86}(x + 136)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27151a7e29555d778aeca6b9e9891706f528db86/include/aws/event-stream/event_stream.h:96:5)"}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_206
+    union (unnamed at /home/runner/.julia/artifacts/a8127c512f94d7b60e3c310154b003d06546779f/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_206
+struct var"union (unnamed at /home/runner/.julia/artifacts/a8127c512f94d7b60e3c310154b003d06546779f/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_206}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8127c512f94d7b60e3c310154b003d06546779f/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_206, f::Symbol)
-    r = Ref{__JL_Ctag_206}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_206}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a8127c512f94d7b60e3c310154b003d06546779f/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a8127c512f94d7b60e3c310154b003d06546779f/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8127c512f94d7b60e3c310154b003d06546779f/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_206}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8127c512f94d7b60e3c310154b003d06546779f/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_206}(x + 132)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a8127c512f94d7b60e3c310154b003d06546779f/include/aws/event-stream/event_stream.h:96:5)"}(x + 132)
     f === :header_value_len && return Ptr{UInt16}(x + 148)
     f === :value_owned && return Ptr{Int8}(x + 150)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_86
+    union (unnamed at /home/runner/.julia/artifacts/1daa4ead5b9689391d2ffb6bb368f91ef3083ac6/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_86
+struct var"union (unnamed at /home/runner/.julia/artifacts/1daa4ead5b9689391d2ffb6bb368f91ef3083ac6/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_86}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1daa4ead5b9689391d2ffb6bb368f91ef3083ac6/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_86, f::Symbol)
-    r = Ref{__JL_Ctag_86}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_86}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1daa4ead5b9689391d2ffb6bb368f91ef3083ac6/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1daa4ead5b9689391d2ffb6bb368f91ef3083ac6/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1daa4ead5b9689391d2ffb6bb368f91ef3083ac6/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_86}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1daa4ead5b9689391d2ffb6bb368f91ef3083ac6/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_86}(x + 132)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1daa4ead5b9689391d2ffb6bb368f91ef3083ac6/include/aws/event-stream/event_stream.h:96:5)"}(x + 132)
     f === :header_value_len && return Ptr{UInt16}(x + 148)
     f === :value_owned && return Ptr{Int8}(x + 150)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_201
+    union (unnamed at /home/runner/.julia/artifacts/aaeae7e41fbf6b701b7c105ba3fd2bbc5ccf52e9/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_201
+struct var"union (unnamed at /home/runner/.julia/artifacts/aaeae7e41fbf6b701b7c105ba3fd2bbc5ccf52e9/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_201}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aaeae7e41fbf6b701b7c105ba3fd2bbc5ccf52e9/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_201, f::Symbol)
-    r = Ref{__JL_Ctag_201}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_201}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/aaeae7e41fbf6b701b7c105ba3fd2bbc5ccf52e9/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/aaeae7e41fbf6b701b7c105ba3fd2bbc5ccf52e9/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aaeae7e41fbf6b701b7c105ba3fd2bbc5ccf52e9/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_201}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aaeae7e41fbf6b701b7c105ba3fd2bbc5ccf52e9/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_201}(x + 132)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/aaeae7e41fbf6b701b7c105ba3fd2bbc5ccf52e9/include/aws/event-stream/event_stream.h:96:5)"}(x + 132)
     f === :header_value_len && return Ptr{UInt16}(x + 148)
     f === :value_owned && return Ptr{Int8}(x + 150)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_86
+    union (unnamed at /home/runner/.julia/artifacts/98470700cff7f61c6a3d6a5333ac4bbdf26d1988/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_86
+struct var"union (unnamed at /home/runner/.julia/artifacts/98470700cff7f61c6a3d6a5333ac4bbdf26d1988/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_86}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98470700cff7f61c6a3d6a5333ac4bbdf26d1988/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_86, f::Symbol)
-    r = Ref{__JL_Ctag_86}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_86}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/98470700cff7f61c6a3d6a5333ac4bbdf26d1988/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/98470700cff7f61c6a3d6a5333ac4bbdf26d1988/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98470700cff7f61c6a3d6a5333ac4bbdf26d1988/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_86}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98470700cff7f61c6a3d6a5333ac4bbdf26d1988/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_86}(x + 132)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98470700cff7f61c6a3d6a5333ac4bbdf26d1988/include/aws/event-stream/event_stream.h:96:5)"}(x + 132)
     f === :header_value_len && return Ptr{UInt16}(x + 148)
     f === :value_owned && return Ptr{Int8}(x + 150)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_201
+    union (unnamed at /home/runner/.julia/artifacts/d75e3b3778cb41b7ee3b60e28a759e84b2e0519b/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_201
+struct var"union (unnamed at /home/runner/.julia/artifacts/d75e3b3778cb41b7ee3b60e28a759e84b2e0519b/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_201}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d75e3b3778cb41b7ee3b60e28a759e84b2e0519b/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_201, f::Symbol)
-    r = Ref{__JL_Ctag_201}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_201}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d75e3b3778cb41b7ee3b60e28a759e84b2e0519b/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d75e3b3778cb41b7ee3b60e28a759e84b2e0519b/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d75e3b3778cb41b7ee3b60e28a759e84b2e0519b/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_201}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d75e3b3778cb41b7ee3b60e28a759e84b2e0519b/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_201}(x + 136)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d75e3b3778cb41b7ee3b60e28a759e84b2e0519b/include/aws/event-stream/event_stream.h:96:5)"}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_76
+    union (unnamed at /home/runner/.julia/artifacts/414ef23acac55f273916ef10cbc65d7524e14a61/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_76
+struct var"union (unnamed at /home/runner/.julia/artifacts/414ef23acac55f273916ef10cbc65d7524e14a61/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_76}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/414ef23acac55f273916ef10cbc65d7524e14a61/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_76, f::Symbol)
-    r = Ref{__JL_Ctag_76}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_76}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/414ef23acac55f273916ef10cbc65d7524e14a61/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/414ef23acac55f273916ef10cbc65d7524e14a61/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/414ef23acac55f273916ef10cbc65d7524e14a61/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_76}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/414ef23acac55f273916ef10cbc65d7524e14a61/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_76}(x + 136)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/414ef23acac55f273916ef10cbc65d7524e14a61/include/aws/event-stream/event_stream.h:96:5)"}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_201
+    union (unnamed at /home/runner/.julia/artifacts/c2555d414938819797553b2525388cf392890f51/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_201
+struct var"union (unnamed at /home/runner/.julia/artifacts/c2555d414938819797553b2525388cf392890f51/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_201}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c2555d414938819797553b2525388cf392890f51/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_201, f::Symbol)
-    r = Ref{__JL_Ctag_201}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_201}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c2555d414938819797553b2525388cf392890f51/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c2555d414938819797553b2525388cf392890f51/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c2555d414938819797553b2525388cf392890f51/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_201}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c2555d414938819797553b2525388cf392890f51/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_201}(x + 136)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c2555d414938819797553b2525388cf392890f51/include/aws/event-stream/event_stream.h:96:5)"}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_86
+    union (unnamed at /home/runner/.julia/artifacts/f228c29bfd18fa677c7ff2cb2b4bb0e1ec852655/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_86
+struct var"union (unnamed at /home/runner/.julia/artifacts/f228c29bfd18fa677c7ff2cb2b4bb0e1ec852655/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_86}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f228c29bfd18fa677c7ff2cb2b4bb0e1ec852655/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_86, f::Symbol)
-    r = Ref{__JL_Ctag_86}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_86}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f228c29bfd18fa677c7ff2cb2b4bb0e1ec852655/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f228c29bfd18fa677c7ff2cb2b4bb0e1ec852655/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f228c29bfd18fa677c7ff2cb2b4bb0e1ec852655/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_86}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f228c29bfd18fa677c7ff2cb2b4bb0e1ec852655/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_86}(x + 136)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f228c29bfd18fa677c7ff2cb2b4bb0e1ec852655/include/aws/event-stream/event_stream.h:96:5)"}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_66
+    union (unnamed at /home/runner/.julia/artifacts/0dc40b230ba617a416fbbadef6bdeadb26835254/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_66
+struct var"union (unnamed at /home/runner/.julia/artifacts/0dc40b230ba617a416fbbadef6bdeadb26835254/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_66}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dc40b230ba617a416fbbadef6bdeadb26835254/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_66, f::Symbol)
-    r = Ref{__JL_Ctag_66}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_66}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0dc40b230ba617a416fbbadef6bdeadb26835254/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0dc40b230ba617a416fbbadef6bdeadb26835254/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dc40b230ba617a416fbbadef6bdeadb26835254/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_66}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dc40b230ba617a416fbbadef6bdeadb26835254/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_66}(x + 136)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0dc40b230ba617a416fbbadef6bdeadb26835254/include/aws/event-stream/event_stream.h:96:5)"}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -77,28 +77,28 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_56
+    union (unnamed at /home/runner/.julia/artifacts/9f5edbdad895e64541833c73ac40fc95706c1e5a/include/aws/event-stream/event_stream.h:96:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_56
+struct var"union (unnamed at /home/runner/.julia/artifacts/9f5edbdad895e64541833c73ac40fc95706c1e5a/include/aws/event-stream/event_stream.h:96:5)"
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_56}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9f5edbdad895e64541833c73ac40fc95706c1e5a/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_56, f::Symbol)
-    r = Ref{__JL_Ctag_56}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_56}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9f5edbdad895e64541833c73ac40fc95706c1e5a/include/aws/event-stream/event_stream.h:96:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9f5edbdad895e64541833c73ac40fc95706c1e5a/include/aws/event-stream/event_stream.h:96:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9f5edbdad895e64541833c73ac40fc95706c1e5a/include/aws/event-stream/event_stream.h:96:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_56}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9f5edbdad895e64541833c73ac40fc95706c1e5a/include/aws/event-stream/event_stream.h:96:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -115,7 +115,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_56}(x + 136)
+    f === :header_value && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9f5edbdad895e64541833c73ac40fc95706c1e5a/include/aws/event-stream/event_stream.h:96:5)"}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -1782,12 +1782,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1797,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_event_stream_jll** to version **0.5.4**
- Updated **JuliaServices/LibAwsEventStream.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings