### PR TITLE
Update aws_c_event_stream_jll to version 0.5.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsEventStream"
 uuid = "7707c54a-f152-44d3-a3d6-cc4209ac0b85"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsChecksums = "1.1"
 LibAwsCommon = "1.2"
 LibAwsIO = "1.2"
-aws_c_event_stream_jll = "=0.4.2"
+aws_c_event_stream_jll = "=0.5.7"
 Test = "1.11"
 julia = "1.6"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_checksums_jll = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
 [compat]
 Clang = "0.18.3,0.19"
 JLLPrefixes = "0.3,0.4"
-aws_c_event_stream_jll = "=0.4.2"
+aws_c_event_stream_jll = "=0.5.7"

--- a/gen/prologue.jl
+++ b/gen/prologue.jl
@@ -1,1 +1,3 @@
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_76
+    __JL_Ctag_21
 
 Documentation not found.
 """
-struct __JL_Ctag_76
+struct __JL_Ctag_21
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_76}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_21}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_76, f::Symbol)
-    r = Ref{__JL_Ctag_76}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_76}, r)
+function Base.getproperty(x::__JL_Ctag_21, f::Symbol)
+    r = Ref{__JL_Ctag_21}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_21}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_76}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_21}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_21, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_76}(x + 136)
+    f === :header_value && return Ptr{__JL_Ctag_21}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """
@@ -74,40 +76,6 @@ Documentation not found.
     AWS_EVENT_STREAM_HEADER_STRING = 7
     AWS_EVENT_STREAM_HEADER_TIMESTAMP = 8
     AWS_EVENT_STREAM_HEADER_UUID = 9
-end
-
-"""
-    __JL_Ctag_21
-
-Documentation not found.
-"""
-struct __JL_Ctag_21
-    data::NTuple{16, UInt8}
-end
-
-function Base.getproperty(x::Ptr{__JL_Ctag_21}, f::Symbol)
-    f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
-    f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::__JL_Ctag_21, f::Symbol)
-    r = Ref{__JL_Ctag_21}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_21}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{__JL_Ctag_21}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
-function Base.propertynames(x::__JL_Ctag_21, private::Bool = false)
-    (:variable_len_val, :static_val, if private
-            fieldnames(typeof(x))
-        else
-            ()
-        end...)
 end
 
 """

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_206
+    __JL_Ctag_101
 
 Documentation not found.
 """
-struct __JL_Ctag_206
+struct __JL_Ctag_101
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_206}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_101}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_206, f::Symbol)
-    r = Ref{__JL_Ctag_206}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_206}, r)
+function Base.getproperty(x::__JL_Ctag_101, f::Symbol)
+    r = Ref{__JL_Ctag_101}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_101}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_206}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_101}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_101, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_206}(x + 136)
+    f === :header_value && return Ptr{__JL_Ctag_101}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_86
+    __JL_Ctag_16
 
 Documentation not found.
 """
-struct __JL_Ctag_86
+struct __JL_Ctag_16
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_86}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_16}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_86, f::Symbol)
-    r = Ref{__JL_Ctag_86}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_86}, r)
+function Base.getproperty(x::__JL_Ctag_16, f::Symbol)
+    r = Ref{__JL_Ctag_16}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_16}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_86}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_16}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_16, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_86}(x + 136)
+    f === :header_value && return Ptr{__JL_Ctag_16}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_206
+    __JL_Ctag_101
 
 Documentation not found.
 """
-struct __JL_Ctag_206
+struct __JL_Ctag_101
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_206}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_101}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_206, f::Symbol)
-    r = Ref{__JL_Ctag_206}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_206}, r)
+function Base.getproperty(x::__JL_Ctag_101, f::Symbol)
+    r = Ref{__JL_Ctag_101}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_101}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_206}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_101}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_101, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_206}(x + 132)
+    f === :header_value && return Ptr{__JL_Ctag_101}(x + 132)
     f === :header_value_len && return Ptr{UInt16}(x + 148)
     f === :value_owned && return Ptr{Int8}(x + 150)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_86
+    __JL_Ctag_16
 
 Documentation not found.
 """
-struct __JL_Ctag_86
+struct __JL_Ctag_16
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_86}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_16}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_86, f::Symbol)
-    r = Ref{__JL_Ctag_86}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_86}, r)
+function Base.getproperty(x::__JL_Ctag_16, f::Symbol)
+    r = Ref{__JL_Ctag_16}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_16}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_86}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_16}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_16, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_86}(x + 132)
+    f === :header_value && return Ptr{__JL_Ctag_16}(x + 132)
     f === :header_value_len && return Ptr{UInt16}(x + 148)
     f === :value_owned && return Ptr{Int8}(x + 150)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_201
+    __JL_Ctag_96
 
 Documentation not found.
 """
-struct __JL_Ctag_201
+struct __JL_Ctag_96
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_201}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_96}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_201, f::Symbol)
-    r = Ref{__JL_Ctag_201}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_201}, r)
+function Base.getproperty(x::__JL_Ctag_96, f::Symbol)
+    r = Ref{__JL_Ctag_96}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_96}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_201}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_96}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_96, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_201}(x + 132)
+    f === :header_value && return Ptr{__JL_Ctag_96}(x + 132)
     f === :header_value_len && return Ptr{UInt16}(x + 148)
     f === :value_owned && return Ptr{Int8}(x + 150)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_86
+    __JL_Ctag_16
 
 Documentation not found.
 """
-struct __JL_Ctag_86
+struct __JL_Ctag_16
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_86}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_16}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_86, f::Symbol)
-    r = Ref{__JL_Ctag_86}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_86}, r)
+function Base.getproperty(x::__JL_Ctag_16, f::Symbol)
+    r = Ref{__JL_Ctag_16}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_16}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_86}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_16}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_16, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_86}(x + 132)
+    f === :header_value && return Ptr{__JL_Ctag_16}(x + 132)
     f === :header_value_len && return Ptr{UInt16}(x + 148)
     f === :value_owned && return Ptr{Int8}(x + 150)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_201
+    __JL_Ctag_96
 
 Documentation not found.
 """
-struct __JL_Ctag_201
+struct __JL_Ctag_96
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_201}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_96}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_201, f::Symbol)
-    r = Ref{__JL_Ctag_201}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_201}, r)
+function Base.getproperty(x::__JL_Ctag_96, f::Symbol)
+    r = Ref{__JL_Ctag_96}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_96}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_201}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_96}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_96, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_201}(x + 136)
+    f === :header_value && return Ptr{__JL_Ctag_96}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_76
+    __JL_Ctag_21
 
 Documentation not found.
 """
-struct __JL_Ctag_76
+struct __JL_Ctag_21
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_76}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_21}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_76, f::Symbol)
-    r = Ref{__JL_Ctag_76}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_76}, r)
+function Base.getproperty(x::__JL_Ctag_21, f::Symbol)
+    r = Ref{__JL_Ctag_21}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_21}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_76}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_21}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_21, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_76}(x + 136)
+    f === :header_value && return Ptr{__JL_Ctag_21}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """
@@ -74,40 +76,6 @@ Documentation not found.
     AWS_EVENT_STREAM_HEADER_STRING = 7
     AWS_EVENT_STREAM_HEADER_TIMESTAMP = 8
     AWS_EVENT_STREAM_HEADER_UUID = 9
-end
-
-"""
-    __JL_Ctag_21
-
-Documentation not found.
-"""
-struct __JL_Ctag_21
-    data::NTuple{16, UInt8}
-end
-
-function Base.getproperty(x::Ptr{__JL_Ctag_21}, f::Symbol)
-    f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
-    f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::__JL_Ctag_21, f::Symbol)
-    r = Ref{__JL_Ctag_21}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_21}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{__JL_Ctag_21}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
-function Base.propertynames(x::__JL_Ctag_21, private::Bool = false)
-    (:variable_len_val, :static_val, if private
-            fieldnames(typeof(x))
-        else
-            ()
-        end...)
 end
 
 """

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_201
+    __JL_Ctag_91
 
 Documentation not found.
 """
-struct __JL_Ctag_201
+struct __JL_Ctag_91
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_201}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_91}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_201, f::Symbol)
-    r = Ref{__JL_Ctag_201}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_201}, r)
+function Base.getproperty(x::__JL_Ctag_91, f::Symbol)
+    r = Ref{__JL_Ctag_91}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_91}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_201}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_91}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_91, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_201}(x + 136)
+    f === :header_value && return Ptr{__JL_Ctag_91}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_86
+    __JL_Ctag_16
 
 Documentation not found.
 """
-struct __JL_Ctag_86
+struct __JL_Ctag_16
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_86}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_16}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_86, f::Symbol)
-    r = Ref{__JL_Ctag_86}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_86}, r)
+function Base.getproperty(x::__JL_Ctag_16, f::Symbol)
+    r = Ref{__JL_Ctag_16}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_16}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_86}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_16}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_16, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_86}(x + 136)
+    f === :header_value && return Ptr{__JL_Ctag_16}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_66
+    __JL_Ctag_16
 
 Documentation not found.
 """
-struct __JL_Ctag_66
+struct __JL_Ctag_16
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_66}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_16}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_66, f::Symbol)
-    r = Ref{__JL_Ctag_66}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_66}, r)
+function Base.getproperty(x::__JL_Ctag_16, f::Symbol)
+    r = Ref{__JL_Ctag_16}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_16}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_66}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_16}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_16, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_66}(x + 136)
+    f === :header_value && return Ptr{__JL_Ctag_16}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,6 +1,8 @@
 using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
+const INT16_MAX = typemax(Int16)
+const uint32_t = UInt32
 
 
 """

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 const INT8_MAX = typemax(Int8)
 
@@ -77,29 +77,37 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_56
+    __JL_Ctag_16
 
 Documentation not found.
 """
-struct __JL_Ctag_56
+struct __JL_Ctag_16
     data::NTuple{16, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_56}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_16}, f::Symbol)
     f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
     f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_56, f::Symbol)
-    r = Ref{__JL_Ctag_56}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_56}, r)
+function Base.getproperty(x::__JL_Ctag_16, f::Symbol)
+    r = Ref{__JL_Ctag_16}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_16}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_56}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_16}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_16, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -115,7 +123,7 @@ function Base.getproperty(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol)
     f === :header_name_len && return Ptr{UInt8}(x + 0)
     f === :header_name && return Ptr{NTuple{127, Cchar}}(x + 1)
     f === :header_value_type && return Ptr{aws_event_stream_header_value_type}(x + 128)
-    f === :header_value && return Ptr{__JL_Ctag_56}(x + 136)
+    f === :header_value && return Ptr{__JL_Ctag_16}(x + 136)
     f === :header_value_len && return Ptr{UInt16}(x + 152)
     f === :value_owned && return Ptr{Int8}(x + 154)
     return getfield(x, f)
@@ -130,6 +138,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_header_value_pair}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_header_value_pair, private::Bool = false)
+    (:header_name_len, :header_name, :header_value_type, :header_value, :header_value_len, :value_owned, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef int ( aws_event_stream_process_state_fn ) ( struct aws_event_stream_streaming_decoder * decoder , const uint8_t * data , size_t len , size_t * processed )
@@ -205,6 +221,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_event_stream_streaming_decoder}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_event_stream_streaming_decoder, private::Bool = false)
+    (:alloc, :working_buffer, :message_pos, :running_crc, :current_header_name_offset, :current_header_value_offset, :current_header, :prelude, :state, :on_payload, :on_prelude, :on_header, :on_complete, :on_error, :user_context, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1220,6 +1244,12 @@ Invoked when a continuation has either been closed with the TERMINATE\\_STREAM f
 """
 const aws_event_stream_rpc_client_stream_continuation_closed_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_stream_continuation_terminated_fn ) ( void * user_data )
+"""
+Invoked after a continuation has been fully destroyed. Listeners know that no further callbacks are possible.
+"""
+const aws_event_stream_rpc_client_stream_continuation_terminated_fn = Cvoid
+
 """
     aws_event_stream_rpc_client_stream_continuation_options
 
@@ -1228,6 +1258,7 @@ Documentation not found.
 struct aws_event_stream_rpc_client_stream_continuation_options
     on_continuation::Ptr{aws_event_stream_rpc_client_stream_continuation_fn}
     on_continuation_closed::Ptr{aws_event_stream_rpc_client_stream_continuation_closed_fn}
+    on_continuation_terminated::Ptr{aws_event_stream_rpc_client_stream_continuation_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1253,6 +1284,12 @@ If the attempt was successful, error\\_code will be 0 and the connection pointer
 """
 const aws_event_stream_rpc_client_on_connection_setup_fn = Cvoid
 
+# typedef void ( aws_event_stream_rpc_client_on_connection_terminated_fn ) ( void * user_data )
+"""
+Invoked when a connection has been completely destroyed.
+"""
+const aws_event_stream_rpc_client_on_connection_terminated_fn = Cvoid
+
 # typedef void ( aws_event_stream_rpc_client_message_flush_fn ) ( int error_code , void * user_data )
 """
 Invoked whenever a message has been flushed to the channel.
@@ -1273,6 +1310,7 @@ struct aws_event_stream_rpc_client_connection_options
     on_connection_setup::Ptr{aws_event_stream_rpc_client_on_connection_setup_fn}
     on_connection_protocol_message::Ptr{aws_event_stream_rpc_client_connection_protocol_message_fn}
     on_connection_shutdown::Ptr{aws_event_stream_rpc_client_on_connection_shutdown_fn}
+    on_connection_terminated::Ptr{aws_event_stream_rpc_client_on_connection_terminated_fn}
     user_data::Ptr{Cvoid}
 end
 
@@ -1360,6 +1398,20 @@ int aws_event_stream_rpc_client_connection_send_protocol_message( struct aws_eve
 """
 function aws_event_stream_rpc_client_connection_send_protocol_message(connection, message_args, flush_fn, user_data)
     ccall((:aws_event_stream_rpc_client_connection_send_protocol_message, libaws_c_event_stream), Cint, (Ptr{aws_event_stream_rpc_client_connection}, Ptr{aws_event_stream_rpc_message_args}, Ptr{aws_event_stream_rpc_client_message_flush_fn}, Ptr{Cvoid}), connection, message_args, flush_fn, user_data)
+end
+
+"""
+    aws_event_stream_rpc_client_connection_get_event_loop(connection)
+
+Returns the event loop that a connection is seated on.
+
+### Prototype
+```c
+struct aws_event_loop *aws_event_stream_rpc_client_connection_get_event_loop( const struct aws_event_stream_rpc_client_connection *connection);
+```
+"""
+function aws_event_stream_rpc_client_connection_get_event_loop(connection)
+    ccall((:aws_event_stream_rpc_client_connection_get_event_loop, libaws_c_event_stream), Ptr{aws_event_loop}, (Ptr{aws_event_stream_rpc_client_connection},), connection)
 end
 
 """
@@ -1782,12 +1834,12 @@ const AWS_C_EVENT_STREAM_PACKAGE_ID = 4
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+const AWS_EVENT_STREAM_MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = 128 * 1024
+const AWS_EVENT_STREAM_MAX_HEADERS_SIZE = AWS_EVENT_STREAM_MAX_MESSAGE_SIZE
 
 """
 Documentation not found.
@@ -1797,9 +1849,15 @@ const AWS_EVENT_STREAM_HEADER_NAME_LEN_MAX = INT8_MAX
 """
 Documentation not found.
 """
-const AWS_EVENT_STREAM_HEADER_STATIC_VALUE_LEN_MAX = 16
+const AWS_EVENT_STREAM_HEADER_VALUE_LEN_MAX = INT16_MAX
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_PRELUDE_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) + sizeof ( uint32_t ) + sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_PRELUDE_LENGTH = uint32_t(12)
 
-# Skipping MacroDefinition: AWS_EVENT_STREAM_TRAILER_LENGTH ( uint32_t ) ( sizeof ( uint32_t ) )
+"""
+Documentation not found.
+"""
+const AWS_EVENT_STREAM_TRAILER_LENGTH = uint32_t(4)
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_event_stream_jll** to version **0.5.7**
- Updated **JuliaServices/LibAwsEventStream.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings