### PR TITLE
Update aws_c_event_stream_jll to version 0.5.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsEventStream"
 uuid = "7707c54a-f152-44d3-a3d6-cc4209ac0b85"
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsChecksums = "1.1"
 LibAwsCommon = "1.2"
 LibAwsIO = "1.2"
-aws_c_event_stream_jll = "=0.5.7"
+aws_c_event_stream_jll = "=0.5.8"
 Test = "1.11"
 julia = "1.6"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_checksums_jll = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
 [compat]
 Clang = "0.18.3,0.19"
 JLLPrefixes = "0.3,0.4"
-aws_c_event_stream_jll = "=0.5.7"
+aws_c_event_stream_jll = "=0.5.8"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -79,6 +79,40 @@ Documentation not found.
 end
 
 """
+    __JL_Ctag_21
+
+Documentation not found.
+"""
+struct __JL_Ctag_21
+    data::NTuple{16, UInt8}
+end
+
+function Base.getproperty(x::Ptr{__JL_Ctag_21}, f::Symbol)
+    f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
+    f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_21, f::Symbol)
+    r = Ref{__JL_Ctag_21}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_21}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_21}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_21, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
+"""
     aws_event_stream_header_value_pair
 
 Documentation not found.

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -79,6 +79,40 @@ Documentation not found.
 end
 
 """
+    __JL_Ctag_21
+
+Documentation not found.
+"""
+struct __JL_Ctag_21
+    data::NTuple{16, UInt8}
+end
+
+function Base.getproperty(x::Ptr{__JL_Ctag_21}, f::Symbol)
+    f === :variable_len_val && return Ptr{Ptr{UInt8}}(x + 0)
+    f === :static_val && return Ptr{NTuple{16, UInt8}}(x + 0)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_21, f::Symbol)
+    r = Ref{__JL_Ctag_21}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_21}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_21}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_21, private::Bool = false)
+    (:variable_len_val, :static_val, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
+"""
     aws_event_stream_header_value_pair
 
 Documentation not found.


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_event_stream_jll** to version **0.5.8**
- Updated **JuliaServices/LibAwsEventStream.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings