### PR TITLE
Update aws_c_event_stream_jll to version 0.5.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsEventStream"
 uuid = "7707c54a-f152-44d3-a3d6-cc4209ac0b85"
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,7 +17,7 @@ LibAwsCal = "1.1"
 LibAwsChecksums = "1.1"
 LibAwsCommon = "1.2"
 LibAwsIO = "1.2"
-aws_c_event_stream_jll = "=0.5.8"
+aws_c_event_stream_jll = "=0.5.9"
 Test = "1.11"
 julia = "1.6"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -14,4 +14,4 @@ aws_checksums_jll = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
 [compat]
 Clang = "0.18.3,0.19"
 JLLPrefixes = "0.3,0.4"
-aws_c_event_stream_jll = "=0.5.8"
+aws_c_event_stream_jll = "=0.5.9"


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_event_stream_jll** to version **0.5.9**
- Updated **JuliaServices/LibAwsEventStream.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings